### PR TITLE
Fix playlist link API error handling

### DIFF
--- a/src/components/LinkPlaylistsButton.tsx
+++ b/src/components/LinkPlaylistsButton.tsx
@@ -39,8 +39,8 @@ export default function LinkPlaylistsButton({
                 "Content-Type": "application/json",
               },
               body: JSON.stringify({
-                spotifyId: spotifyPlaylist.id,
-                neteaseId: neteasePlaylist.id,
+                spotifyPlaylistId: spotifyPlaylist.id,
+                neteasePlaylistId: neteasePlaylist.id,
                 userId: userId,
               }),
             });


### PR DESCRIPTION
Fixed "Missing required fields" error by updating the request body field names:
- Changed spotifyId to spotifyPlaylistId
- Changed neteaseId to neteasePlaylistId

This matches the expected field names in /api/playlists/link route handler.